### PR TITLE
Warp training using discrete images in place of continuous ones.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ experiments/frll_neutral_front_cropped/*
 .vscode/
 data/frll_neutral_front_cropped
 data/frll_neutral_front
+.venv

--- a/experiments/001_002-baseline_discrete.yaml
+++ b/experiments/001_002-baseline_discrete.yaml
@@ -561,6 +561,6 @@ reconstruct:
 training:
   checkpoint_steps: 1000
   n_samples: 20000
-  n_steps: 3001
+  n_steps: 21001
   reconstruction_steps: 1000
   warmup_steps: 1000

--- a/ifmorph/dataset.py
+++ b/ifmorph/dataset.py
@@ -150,14 +150,16 @@ class ImageDataset(Dataset):
             intcoords = (self.coords.detach().clone().cpu() * 0.5 + 0.5)
         else:
             intcoords = (coords.detach().clone().cpu() * 0.5 + 0.5)
-        intcoords = intcoords.clamp(-1, 1)
+        intcoords = intcoords.clamp(self.coords.min(), self.coords.max())
         intcoords[..., 0] *= self.size[0]
         intcoords[..., 1] *= self.size[1]
         intcoords = intcoords.floor().long()
-        return self.rgb[
+        rgb = torch.zeros_like(self.rgb, device=self.device)
+        rgb = self.rgb[
             (intcoords[..., 0] * self.size[0]) + intcoords[..., 1],
             ...
         ]
+        return rgb
 
     def __len__(self):
         return math.ceil(self.rgb.shape[0] / self.batch_size)

--- a/ifmorph/dataset.py
+++ b/ifmorph/dataset.py
@@ -154,7 +154,7 @@ class ImageDataset(Dataset):
         intcoords[..., 0] *= self.size[0]
         intcoords[..., 1] *= self.size[1]
         intcoords = intcoords.floor().long()
-        rgb = torch.zeros_like(self.rgb, device=self.device)
+        rgb = torch.zeros_like(self.rgb, device=self.coords.device)
         rgb = self.rgb[
             (intcoords[..., 0] * self.size[0]) + intcoords[..., 1],
             ...

--- a/ifmorph/dataset.py
+++ b/ifmorph/dataset.py
@@ -134,21 +134,29 @@ class ImageDataset(Dataset):
         else:
             self.batch_size = batch_size
 
-    def pixels(self, coords):
+    def pixels(self, coords=None):
         """
         Parameters
         ----------
         coords: torch.Tensor
-            Point tensor in range [-1, 1]. Must have shape Nx2.
+            Point tensor in range [-1, 1]. Must have shape [N, 2].
+
+        Returns
+        -------
+        rgb: torch.Tensor
+            RGB values shaped [N, 3].
         """
-        intcoords = coords.detach().clone().cpu() * 0.5 + 0.5
+        if coords is None:
+            intcoords = (self.coords.detach().clone().cpu() * 0.5 + 0.5)
+        else:
+            intcoords = (coords.detach().clone().cpu() * 0.5 + 0.5)
         intcoords[..., 0] *= self.size[0]
         intcoords[..., 1] *= self.size[1]
-        intcoords = intcoords.long()
-        return self.rgb[intcoords[..., 0] * intcoords[..., 1], ...]
+        intcoords = intcoords.floor().long()
+        return self.rgb[(intcoords[..., 0] * self.size[0]) + intcoords[..., 1], ...]
 
     def __len__(self):
-        return self.rgb.shape[0] // self.batch_size
+        return math.ceil(self.rgb.shape[0] / self.batch_size)
 
     def __getitem__(self, idx=None):
         """
@@ -173,6 +181,7 @@ class ImageDataset(Dataset):
             idx = torch.randint(self.coords.shape[0], (self.batch_size,))
         elif not isinstance(idx, torch.Tensor):
             idx = torch.Tensor(idx)
+        idx = idx.to(self.coords.device)
         return self.coords[idx, ...], self.rgb[idx, ...], idx
 
 
@@ -397,16 +406,23 @@ class NoTimeWarpingDataset(WarpingDataset):
 
 
 if __name__ == "__main__":
-    wd = DiscreteImageWarpingDataset(
-        [("data/frll_neutral_front/001_03.jpg", 0.0), ("data/frll_neutral_front/002_03.jpg", 1.0)],
-        20
-    )
-    print(wd.batch_size, wd.im_batch_size)
-    pts = wd.__getitem__(None)
+    import torchvision.transforms.functional as F
+    # wd = DiscreteImageWarpingDataset(
+    #     [("data/frll_neutral_front/001_03.jpg", 0.0), ("data/frll_neutral_front/002_03.jpg", 1.0)],
+    #     20
+    # )
+    # print(wd.batch_size, wd.im_batch_size)
+    # pts = wd.__getitem__(None)
 
-    # im = ImageDataset("data/frll_neutral_front/001_03.jpg", batch_size=30)
-    # X, y = im.__getitem__(None)
-    # print(X.shape, y.shape)
+    im = ImageDataset("data/001_03.jpg", batch_size=0)
+    idx = torch.arange(im.rgb.shape[0])
+    X, y, _ = im.__getitem__(idx)
+    print(X.shape, y.shape)
+
+    pix = im.pixels()  # y.detach().clone()
+    rgb = pix.reshape([im.size[0], im.size[1], 3]).permute((2, 0, 1))
+    rgb = F.to_pil_image(rgb)
+    rgb.save("test.png")
     # X, y = im.__getitem__([])
     # print(X.shape, y.shape)
     # X, y = im.__getitem__()

--- a/ifmorph/dataset.py
+++ b/ifmorph/dataset.py
@@ -150,10 +150,14 @@ class ImageDataset(Dataset):
             intcoords = (self.coords.detach().clone().cpu() * 0.5 + 0.5)
         else:
             intcoords = (coords.detach().clone().cpu() * 0.5 + 0.5)
+        intcoords = intcoords.clamp(-1, 1)
         intcoords[..., 0] *= self.size[0]
         intcoords[..., 1] *= self.size[1]
         intcoords = intcoords.floor().long()
-        return self.rgb[(intcoords[..., 0] * self.size[0]) + intcoords[..., 1], ...]
+        return self.rgb[
+            (intcoords[..., 0] * self.size[0]) + intcoords[..., 1],
+            ...
+        ]
 
     def __len__(self):
         return math.ceil(self.rgb.shape[0] / self.batch_size)
@@ -423,18 +427,4 @@ if __name__ == "__main__":
     rgb = pix.reshape([im.size[0], im.size[1], 3]).permute((2, 0, 1))
     rgb = F.to_pil_image(rgb)
     rgb.save("test.png")
-    # X, y = im.__getitem__([])
-    # print(X.shape, y.shape)
-    # X, y = im.__getitem__()
-    # print(X.shape, y.shape)
 
-    # idx = torch.randint(100, (im.batch_size,))
-    # X, y = im.__getitem__(idx)
-    # print(X.shape, y.shape)
-    # data = WarpingDataset([
-    #     ("pretrained/yaleB01_P00A+000E+00.pth", -0.5),
-    #     ("pretrained/yaleB11_P00A+000E+00.pth", 0.0),
-    #     ("pretrained/yaleB27_P00A+000E+00.pth", 0.5)
-    # ], 48)
-    # X = data[0]
-    # print(X.shape)

--- a/ifmorph/util.py
+++ b/ifmorph/util.py
@@ -90,7 +90,9 @@ def get_grid(dims, requires_grad=False, list_of_coords=True):
     """
     if isinstance(dims, int):
         dims = [dims]
-    tensors = tuple([torch.linspace(-1, 1, steps=d) for d in dims])
+    tensors = tuple([
+        torch.linspace(-1+(1.0/d), 1-(1.0/d), steps=d) for d in dims
+    ])
     mgrid = torch.stack(torch.meshgrid(*tensors, indexing="ij"), dim=-1)
     if list_of_coords:
         mgrid = mgrid.reshape(-1, len(dims))

--- a/ifmorph/util.py
+++ b/ifmorph/util.py
@@ -438,7 +438,6 @@ def create_morphing_video(
         frame_dims: tuple,
         n_frames: int,
         fps: int,
-        ic_times: list,
         device: torch.device,
         src,
         tgt,
@@ -468,9 +467,6 @@ def create_morphing_video(
 
     fps: int
         Frames-per-second of the video.
-
-    ic_times: list
-        The times of the initial conditions.
 
     device: torch.device
         The device to run the inference for all networks. All intermediate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dlib=19.24.4
+dlib==19.24.4
 matplotlib==3.6.0
 mediapipe==0.9.1.0
 numpy==1.23.3

--- a/warp-train-image.py
+++ b/warp-train-image.py
@@ -116,7 +116,7 @@ def train_warping(experiment_config_path, output_path, args):
         reconstruct_steps = training_config.get("reconstruction_steps", None)
 
     reconstruct_config = config["reconstruct"]
-    timerange = reconstruct_config.get("timerange", [-1, 1])
+    # timerange = reconstruct_config.get("timerange", [-1, 1])
     n_frames = reconstruct_config.get("n_frames", 100)
     fps = reconstruct_config.get("fps", 10)
     grid_dims = reconstruct_config.get("frame_dims", (320, 320))

--- a/warp-train-image.py
+++ b/warp-train-image.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import argparse
+from copy import deepcopy
+from enum import Enum
+from multiprocessing import Pool
+import os
+import os.path as osp
+import random
+import sys
+import numpy as np
+import pandas as pd
+import torch
+from torch.utils.tensorboard import SummaryWriter
+import yaml
+from ifmorph.dataset import DiscreteImageWarpingDataset
+from ifmorph.loss_functions import FeatureMatchingWarpingLoss
+from ifmorph.model import SIREN
+from ifmorph.util import (discrete_morphing_video, return_points_morph,
+                          return_points_morph_mediapipe)
+
+
+class LoggerType(Enum):
+    TENSORBOARD = "tensorboard"
+    NONE = "none"
+
+
+def train_warping(experiment_config_path, output_path, args):
+    """Runs a single warp training.
+
+    Parameters
+    ----------
+    experiment_config_path: str, PathLike
+        Path to the experiment configuration file.
+
+    output_path: str, PathLike
+        Path to the output folder.
+
+    args: argparse.Namespace
+        Other relevant arguments.
+    """
+    if not osp.exists(experiment_config_path):
+        raise FileNotFoundError("Experiment configuration file not found.")
+
+    with open(experiment_config_path, "r") as fin:
+        config = yaml.safe_load(fin)
+
+    experiment_name = osp.splitext(osp.split(experiment_config_path)[-1])[0]
+    config["experiment_name"] = experiment_name
+
+    os.makedirs(output_path, exist_ok=True)
+
+    logger_type = LoggerType(args.logging)
+    if logger_type == LoggerType.TENSORBOARD:
+        summary_path = osp.join(output_path, 'summaries')
+        if not osp.exists(summary_path):
+            os.makedirs(summary_path)
+        writer = SummaryWriter(summary_path)
+
+    with open(osp.join(output_path, "config.yaml"), "w") as fout:
+        yaml.dump(config, fout)
+
+    devstr = ""
+    if args.device:
+        devstr = args.device
+    else:
+        devstr = config.get("device", "cuda:0")
+
+    if "cuda" in devstr and not torch.cuda.is_available():
+        devstr = "cpu"
+        print("No CUDA available devices found on system. Using CPU.",
+              file=sys.stderr)
+    else:
+        torch.cuda.empty_cache()
+
+    device = torch.device(devstr)
+
+    initial_conditions = [(v, k) for k, v in config["initial_conditions"].items()]
+    data = DiscreteImageWarpingDataset(
+        initial_conditions,
+        num_samples=config["training"]["n_samples"],
+        device=device
+    )
+
+    network_config = config["network"]
+    model = SIREN(
+        n_in_features=network_config["in_channels"],
+        n_out_features=network_config["out_channels"],
+        hidden_layer_config=network_config["hidden_layers"],
+        w0=network_config["omega_0"],
+        ww=network_config.get("omega_w", None),
+        delay_init=True
+    ).to(device)
+
+    # identity initialization
+    init_type = network_config.get("initialization", "siren")
+    if init_type == "siren":
+        model.reset_weights()
+    else:
+        raise NotImplementedError("Only \"siren\" initialization is implemented.")
+
+    optim_config = config["optimizer"]
+    optim = torch.optim.Adam(
+        lr=optim_config["lr"],
+        params=model.parameters()
+    )
+
+    loss_config = config["loss"]
+    training_config = config["training"]
+    training_steps = training_config["n_steps"]
+    warmup_steps = training_config.get("warmup_steps", training_steps // 10)
+    checkpoint_steps = training_config.get("checkpoint_steps", None)
+    reconstruct_steps = None
+    if not args.no_reconstruction:
+        reconstruct_steps = training_config.get("reconstruction_steps", None)
+
+    reconstruct_config = config["reconstruct"]
+    timerange = reconstruct_config.get("timerange", [-1, 1])
+    n_frames = reconstruct_config.get("n_frames", 100)
+    fps = reconstruct_config.get("fps", 10)
+    grid_dims = reconstruct_config.get("frame_dims", (320, 320))
+
+    best_loss = np.inf
+    best_step = warmup_steps
+    training_loss = {}
+
+    if loss_config["type"] == "featurematching":
+        src, tgt = None, None
+        if "sources" not in loss_config or "targets" not in loss_config:
+            src, tgt, _, _ = return_points_morph_mediapipe(
+                data.initial_states[0],
+                data.initial_states[1],
+                grid_dims,
+                device=device,
+            )
+        elif isinstance(loss_config["sources"], str) or \
+             isinstance(loss_config["targets"], str):
+            with open(loss_config["sources"], 'r') as fin:
+                src = np.array(yaml.safe_load(fin))
+
+            with open(loss_config["targets"], 'r') as fin:
+                tgt = np.array(yaml.safe_load(fin))
+        else:
+            src = np.array(loss_config["sources"])
+            tgt = np.array(loss_config["targets"])
+
+        if not args.no_ui:
+            src, tgt, _, _ = return_points_morph(
+                data.initial_states[0],
+                data.initial_states[1],
+                grid_dims,
+                src_pts=src,
+                tgt_pts=tgt,
+                device=device,
+                run_mediapipe=False
+            )
+
+        int_times = loss_config.get("intermediate_times", [0.25, 0.5, 0.75])
+        constraint_weights = loss_config.get("constraint_weights", None)
+
+        for k, v in constraint_weights.items():
+            constraint_weights[k] = float(v)
+
+        src = torch.tensor(src, dtype=torch.float32).to(device)
+        tgt = torch.tensor(tgt, dtype=torch.float32).to(device)
+        if args.noise_scale:
+            print(f"Running with landmark noise: {args.noise_scale}")
+            noisesrc = (2 * torch.rand_like(src) - 1) * args.noise_scale
+            noisetgt = (2 * torch.rand_like(tgt) - 1) * args.noise_scale
+            src = src + noisesrc
+            tgt = tgt + noisetgt
+
+        loss_config["sources"] = src.detach().clone().cpu().numpy().tolist()
+        loss_config["targets"] = tgt.detach().clone().cpu().numpy().tolist()
+        loss_config["noise_scale"] = args.noise_scale
+
+        loss_func = FeatureMatchingWarpingLoss(
+            warp_src_pts=src,
+            warp_tgt_pts=tgt,
+            intermediate_times=int_times,
+            constraint_weights=constraint_weights
+        )
+    else:
+        raise NotImplementedError("Only \"featurematching\" loss is supported.")
+
+    config["loss"] = loss_config
+    with open(osp.join(output_path, "config.yaml"), "w") as fout:
+        yaml.dump(config, fout)
+
+    # Logging the images and landmarks
+    # if logger_type == LoggerType.TENSORBOARD:
+    #     writer.add_image(
+    #         "initial_states/source", src_img, dataformats="HW"
+    #     )
+    #     writer.add_image(
+    #         "initial_states/target", tgt_img, dataformats="HW"
+    #     )
+
+    for step in range(training_steps):
+        X = data[0]
+        X = X.to(device)
+
+        yhat = model(X)
+        X = yhat["model_in"]
+        yhat = yhat["model_out"].squeeze()
+        loss = loss_func(X, model)
+
+        # Accumulating the losses.
+        running_loss = torch.zeros((1, 1)).to(device)
+        for k, v in loss.items():
+            running_loss += v
+            if k not in training_loss:
+                training_loss[k] = [v.item()]
+            else:
+                training_loss[k].append(v.item())
+
+            # Logging individual loss terms.
+            if logger_type == LoggerType.TENSORBOARD:
+                writer.add_scalar(f"train_loss/{k}", v.item(), step)
+
+        # Logging the total training loss.
+        if logger_type == LoggerType.TENSORBOARD:
+            writer.add_scalar("train_loss/total_loss", running_loss.item(), step)
+
+        if not step % 1000:
+            print(step, running_loss.item())
+
+        if step > warmup_steps and running_loss.item() < best_loss:
+            best_step = step
+            best_loss = running_loss.item()
+            best_weights = deepcopy(model.state_dict())
+
+        if checkpoint_steps is not None and step > 0 and not step % checkpoint_steps:
+            torch.save(
+                model.state_dict(),
+                osp.join(output_path, f"checkpoint_{step}.pth")
+            )
+
+        if reconstruct_steps is not None and step > 0 and not step % reconstruct_steps:
+            print("Running the inference.")
+            model = model.eval()
+            vidpath = osp.join(output_path, f"rec_{step}.mp4")
+            with torch.no_grad():
+                discrete_morphing_video(
+                    warp_net=model,
+                    frame0=data.initial_states[0],
+                    frame1=data.initial_states[1],
+                    output_path=vidpath,
+                    n_frames=n_frames,
+                    fps=fps,
+                    device=device,
+                    landmarks_src=src,
+                    landmarks_tgt=tgt,
+                    plot_landmarks=True
+                )
+            print("Inference done.")
+            model = model.train().to(device)
+
+        optim.zero_grad()
+        running_loss.backward()
+        optim.step()
+
+    print("Training done.")
+    print(f"Best results at step {best_step}, with loss {best_loss}.")
+    print(f"Saving the results in folder {output_path}.")
+    model = model.eval()
+    with torch.no_grad():
+        model.update_omegas(w0=1, ww=None)
+        torch.save(
+            model.state_dict(), osp.join(output_path, "weights.pth")
+        )
+
+        model.w0 = network_config["omega_0"]
+        model.ww = network_config["omega_w"]
+        print(model.w0, model.ww)
+        model.load_state_dict(best_weights)
+        model.update_omegas(w0=1, ww=None)
+        torch.save(
+            model.state_dict(), osp.join(output_path, "best.pth")
+        )
+
+    loss_df = pd.DataFrame.from_dict(training_loss)
+    loss_df.to_csv(osp.join(output_path, "loss.csv"), sep=";")
+
+    if not args.no_reconstruction:
+        print("Running the inference.")
+
+        vidpath = osp.join(output_path, "video.mp4")
+        discrete_morphing_video(
+            warp_net=model,
+            frame0=data.initial_states[0],
+            frame1=data.initial_states[1],
+            output_path=vidpath,
+            n_frames=n_frames,
+            fps=fps,
+            device=device,
+            landmarks_src=src,
+            landmarks_tgt=tgt
+        )
+        print("Inference done.")
+
+    if logger_type == LoggerType.TENSORBOARD:
+        writer.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "config_path", nargs='+', help="Path to experiment configuration"
+        " files."
+    )
+    parser.add_argument(
+        "--logging", default="tensorboard", type=str,
+        help="Type of logging to use. May be one of: tensorboard, none."
+        "By default is \"tensorboard\"."
+    )
+    parser.add_argument(
+        "--seed", default=123, type=int,
+        help="Seed for the RNG. By default its 123."
+    )
+    parser.add_argument(
+        "--n-tasks", default=1, type=int,
+        help="Number of parallel trainings to run. By default is set to 1,"
+        " meaning that we run serially."
+    )
+    parser.add_argument(
+        "--skip-finished", action="store_true",
+        help="Skips running an experiment if the output path contains the"
+        " \"weights.pth\" file."
+    )
+    parser.add_argument(
+        "--output-path", "-o", default="results",
+        help="Optional output path to store experimental results. By default"
+        " we use the experiment filename and create a matching directory"
+        " under folder \"results\"."
+    )
+    parser.add_argument(
+        "--noise-scale", "-s", default=0, type=float,
+        help="The scale of the noise to apply to the landmark points. Defaults"
+        " to 0, meaning no noise is to be applied. Passing 1 will result in"
+        " completely random points."
+    )
+    parser.add_argument(
+        "--no-ui", "-n", action="store_true", default=False,
+        help="Does not open the UI for point adjustments. Useful when running"
+        " in batches."
+    )
+    parser.add_argument(
+        "--device", "-d", type=str, default="cuda:0", help="Device to run the"
+        " training. Overrides the experiment configuration if present."
+    )
+    parser.add_argument(
+        "--no-reconstruction", action="store_true", help="Bypasses the"
+        " configuration and runs no intermediate/final reconstructions."
+    )
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+    random.seed(args.seed)
+
+    paths_to_run = []
+    for p in args.config_path:
+        fname = osp.splitext(osp.split(p)[-1])[0]  # removing the file extension
+        outpath = osp.join(args.output_path, f"{fname}")
+        weights_path = osp.join(outpath, "weights.pth")
+        if args.skip_finished and osp.exists(weights_path):
+            print(f"{fname} is already trained. Skipping")
+            continue
+        paths_to_run.append((p, outpath))
+
+    if args.n_tasks > 1:
+        pool = Pool(processes=args.n_tasks)
+        for p, o in paths_to_run:
+            pool.apply_async(func=train_warping, args=(p, o, args))
+
+        pool.close()
+        pool.join()
+    else:
+        for p, o in paths_to_run:
+            train_warping(p, o, args)

--- a/warp-train.py
+++ b/warp-train.py
@@ -116,7 +116,7 @@ def train_warping(experiment_config_path, output_path, args):
         reconstruct_steps = training_config.get("reconstruction_steps", None)
 
     reconstruct_config = config["reconstruct"]
-    timerange = reconstruct_config.get("timerange", [-1, 1])
+    # timerange = reconstruct_config.get("timerange", [-1, 1])
     n_frames = reconstruct_config.get("n_frames", 100)
     fps = reconstruct_config.get("fps", 10)
     grid_dims = reconstruct_config.get("frame_dims", (320, 320))
@@ -250,7 +250,6 @@ def train_warping(experiment_config_path, output_path, args):
                     frame_dims=grid_dims,
                     n_frames=n_frames,
                     fps=fps,
-                    ic_times=timerange,
                     device=device,
                     src=src,
                     tgt=tgt,
@@ -297,7 +296,6 @@ def train_warping(experiment_config_path, output_path, args):
             frame_dims=grid_dims,
             n_frames=n_frames,
             fps=fps,
-            ic_times=timerange,
             device=device,
             src=src,
             tgt=tgt


### PR DESCRIPTION
Created a new script to train a warping `warp-train-image.py`. Most of the changes were in `ifmorph.dataset`. Created a new dataset for warping using discrete images (`DiscreteImageWarpingDataset`). Significant changes to `ImageDataset` as well, finally added batching code to the image dataset. Passing the pixel indices to `ImageDataset.__getitem__`  and returning the indices as well to propagate them to other instances (not used anymore, but kept the change).